### PR TITLE
Build config for older Ubuntus

### DIFF
--- a/Build/build-linux.mk
+++ b/Build/build-linux.mk
@@ -1,5 +1,19 @@
+# GDR - 20180617.01 >> distro/release-specific gubbins
+OS=$(shell lsb_release -si)
+ARCH=$(shell uname -m | sed 's/x86_//;s/i[3-6]86/32/')
+VER=$(shell lsb_release -sr)
+
+# - specifically for Ubuntu 16 - path to qmake post installation
+
 # tools
-QMAKE                         := /opt/QtSDK/Desktop/Qt/473/gcc/bin/qmake
+ifeq ($(OS),Ubuntu)
+  QMAKE                         := qmake
+else
+  # GDR - why would this be path-specific anyway?
+  QMAKE                         := /opt/QtSDK/Desktop/Qt/473/gcc/bin/qmake
+endif
+# << GDR - 20180617.01
+
 MAKE                          := make
 RM                            := rm
 MKDIR                         := mkdir

--- a/README.Gemini-Ubuntu
+++ b/README.Gemini-Ubuntu
@@ -1,5 +1,5 @@
 The distributed pre-compiled version of the flasher for Linux is dynamically 
-linked against runs on libpng v1.6.  Ubuntu 14.04 and Ubuntu 16.04 have libpng 
+linked against libpng v1.6.  Ubuntu 14.04 and Ubuntu 16.04 have libpng 
 v1.2.  To run the flasher on these releases the flasher needs to be compiled 
 from source.
 

--- a/README.Gemini-Ubuntu
+++ b/README.Gemini-Ubuntu
@@ -1,7 +1,7 @@
 The distributed pre-compiled version of the flasher for Linux is dynamically 
 linked against libpng v1.6.  Ubuntu 14.04 and Ubuntu 16.04 have libpng 
-v1.2.  To run the flasher on these releases the flasher needs to be compiled 
-from source.
+v1.2.  To run the flasher on these releases it needs to be compiled from 
+source.
 
 In addition to basic development tools and the source from Github at least the 
 following dependencies will need to be fulfilled.

--- a/README.Gemini-Ubuntu
+++ b/README.Gemini-Ubuntu
@@ -1,0 +1,17 @@
+The distributed pre-compiled version of the flasher for Linux is dynamically 
+linked against runs on libpng v1.6.  Ubuntu 14.04 and Ubuntu 16.04 have libpng 
+v1.2.  To run the flasher on these releases the flasher needs to be compiled 
+from source.
+
+In addition to basic development tools and the source from Github at least the 
+following dependencies will need to be fulfilled.
+ * qt4-dev-tools (and dependencies)
+ * libqtwebkit4
+ * libqtwebkit-dev
+
+(sudo apt-get -y install qt4-dev-tools libqtwebkit4 libqtwebkit-dev)
+
+Once compiled the binary executable will be in ${repo}/../_Output 
+
+e.g. source in ~/gitrepo/SP-Flash-Tool-src will lead to the executable (and 
+all the compiled objects from which it is linked) being in ~/gitrepo/_Output.


### PR DESCRIPTION
This change enables the flash tool to be compiled on Ubuntu 16.04 LTS (and probably also works for 14.04 LTS which whilst old remains current). To run the tool on these platforms it is necessary to compile locally, since the pre-compiled binary being distributed is linked against libpng.so.16 which is not available on 14.04, and not default on 16.04.

The Makefile distributed in source does not account for the location of qmake as installed on these.

Also added are some very brief notes on dependencies that will need to be installed to allow compilation.
